### PR TITLE
Update blog-post-workflow.yml

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Pull in dev.to posts
         uses: gautamkrishnar/blog-post-workflow@master
         with:
-          feed_list: "https://kevinfeng-cs88.medium.com/feed"
+          feed_list: "http://www.rssmix.com/u/13565005/rss.xml"


### PR DESCRIPTION
should serve as a workaround to medium blocking github public IP